### PR TITLE
Include information on how to find install path using Steam interface

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,16 +5,16 @@ Feel free to fork this file and adjust it accordingly to your needs.
 
 ## How to use?
 
-Save this file inside your CS:GO cfg folder. The path should look similar to 
+Save this file inside your CS:GO cfg folder. You cand find game install location using Steam:
+- In your library tab, right-click _Counter-Strike: Global Offensive_ and select __Properties__
+- Go to __Local Files__ tab
+- Select __BROWSE LOCAL FILES__. Windows Explorer will be opened in the folder where game is installed.
+- Navigate to _csgo > cfg_. This is the place where the file should be placed.
+
+For the default path installation, it should look similar to 
 
 ```
-Windows(C:) > Program Files (x86) > Steam > userdata > (your own numbers) > (your own 3 digit file) > local > cfg
-```
-
-A shell script (for windows CMD) to find the default configuration file for CS:GO among other installed apps (in a 64bits machine with default installation folder):
-
-```
-cd %PROGRAMFILES(X86)% && dir * /s/b | findstr Steam\\userdata\\[0-9]*\\[0-9]*\\local\\cfg\\config.cfg
+Windows(C:) > Program Files (x86) > Steam > steamapps > common > Counter-Strike Global Offensive > csgo > cfg
 ```
 
 You may save it to any name you like, as long as it keeps the .cfg extension.

--- a/custom.cfg
+++ b/custom.cfg
@@ -5,9 +5,9 @@
 //     Feel free to fork this file and adjust it accordingly to your needs.     //
 //                                                                              //
 // Save this file inside your CS:GO cfg folder. The path should look similar to //
-// Windows(C:) > Program Files (x86) > Steam > userdata > (your own numbers) >  //
-// > (your own 3 digit file) > local > cfg. You may save it to any name you     //
-// like, as long as it keeps the .cfg extension.                                //
+// Windows(C:) > Program Files (x86) > Steam > steamapps > common >             //
+// Counter-Strike Global Offensive > csgo > cfg. You may save it to any name    //
+// you like, as long as it keeps the .cfg extension.                            //
 //                                                                              //
 // To run, you have two options:                                                //
 //   1 - Setting it to the launcher (auto-loaded when the game is started):     //


### PR DESCRIPTION
On top of it, I've made some additional changes:
- Changed the path used as example. I believe the path used in the example will work fine, but the new path is easier to find because it won't depend on _random_ numbers used as user id.
- Removed the cmd command used to find custom.cfg file, using Steam interface will be easier and more reliable.